### PR TITLE
[Document] add readme for webapp gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Azure Plugins for Gradle 
+# Azure Plugins for Gradle
 This repository contains all Microsoft Azure plugins for Gradle.
 
 Azure Plugin | Gradle Plugin Portal | Build Status
 ---|---|---
-[Azure Functions Plugin for Gradle](./azure-functions-gradle-plugin/README.md) | [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v.svg?colorB=007ec6&label=Azure+Functions+Plugin+for+Gradle&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2Fmicrosoft%2Fazure%2Fazure-functions-gradle-plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.microsoft.azure.azurefunctions) | [![Build Status](https://dev.azure.com/mseng/VSJava/_apis/build/status/Azure-Gradle-Plugin/VSCJava-Release-Azure-Gradle-Plugin?branchName=master)](https://dev.azure.com/mseng/VSJava/_build/latest?definitionId=9965&branchName=master)
-
+[Azure Functions Plugin for Gradle](./azure-functions-gradle-plugin/README.md) | [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v.svg?colorB=007ec6&label=Azure+Functions+Plugin+for+Gradle&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2Fmicrosoft%2Fazure%2Fazure-functions-gradle-plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.microsoft.azure.azurefunctions) | [![Build Status](https://dev.azure.com/mseng/VSJava/_apis/build/status/Azure-Gradle-Plugin/VSCJava-Release-Azure-Gradle-Plugin?branchName=master)](https://dev.azure.com/mseng/VSJava/_build/latest?definitionId=10061&branchName=master)
+[Azure WebApp Plugin for Gradle](./azure-webapp-gradle-plugin/README.md) | [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v.svg?colorB=007ec6&label=Azure+WebApp+Plugin+for+Gradle&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2Fmicrosoft%2Fazure%2Fazure-webapp-gradle-plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.microsoft.azure.azurewebapp) | [![Build Status](https://dev.azure.com/mseng/VSJava/_apis/build/status/Azure-Gradle-Plugin/VSCJava-Release-Azure-Gradle-Plugin?branchName=master)](https://dev.azure.com/mseng/VSJava/_build/latest?definitionId=10061&branchName=master)
 ## Feedback and Questions
 To report bugs or request new features, file issues on [Issues](https://github.com/microsoft/azure-gradle-plugins/issues). Or, ask questions on [Stack Overflow with tag azure-java-tools](https://stackoverflow.com/questions/tagged/azure-java-tools).
 

--- a/azure-functions-gradle-plugin/README.md
+++ b/azure-functions-gradle-plugin/README.md
@@ -8,7 +8,7 @@ This plugin provides seamless integration into Gradle projects. You can package 
 Tool | Required Version
 ---|---
 JDK | 1.8
-Gradle | 4.10 and above
+Gradle | 5.2 and above
 [.Net Core SDK](https://www.microsoft.com/net/core) | Latest version
 [Azure Functions Core Tools](https://www.npmjs.com/package/azure-functions-core-tools) | 2.0 and above
 >Note: [See how to install Azure Functions Core Tools - 2.x](https://aka.ms/azfunc-install)
@@ -18,13 +18,13 @@ Gradle | 4.10 and above
 In your Gradle Java project, add the plugin to your `build.gradle`:
 ```groovy
 plugins {
-  id "com.microsoft.azure.azurefunctions" version "1.5.0"
+  id "com.microsoft.azure.azurefunctions" version "1.6.0"
 }
 ```
 
 ## Configuration
 Here is a sample configuration, for details, please refer to this [document](https://github.com/microsoft/azure-gradle-plugins/wiki/Configuration).
-```groovy 
+```groovy
 azurefunctions {
     subscription = <your subscription id>
     resourceGroup = <your resource group>
@@ -39,9 +39,9 @@ azurefunctions {
     }
 
     authentication {
-        type = 'azure_cli' 
+        type = 'azure_cli'
     }
-    // enable local debug 
+    // enable local debug
     // localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
     deployment {
         type = 'run_from_blob'

--- a/azure-webapp-gradle-plugin/CHANGELOG.md
+++ b/azure-webapp-gradle-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to the "Azure WebApp Plugin for Gradle" will be documented in this file.
+- [Change Log](#change-log)
+  - [1.0.0](#100)
+
+## 1.0.0
+- Deploy azure webapp

--- a/azure-webapp-gradle-plugin/README.md
+++ b/azure-webapp-gradle-plugin/README.md
@@ -1,0 +1,61 @@
+# Azure WebApp Plugin for Gradle
+[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v.svg?colorB=007ec6&label=Azure+WebApp+Plugin+for+Gradle&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2Fmicrosoft%2Fazure%2Fazure-webapp-gradle-plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.microsoft.azure.azurewebapp)
+
+This plugin helps Java developers to deploy Maven projects to [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/).
+
+
+## Prerequisites
+
+Tool | Required Version
+---|---
+JDK | 1.8
+Gradle | 5.2 and above
+
+
+## Setup
+In your Gradle Java project, add the plugin to your `build.gradle`:
+```groovy
+plugins {
+  id "com.microsoft.azure.azurewebapp" version "1.0.0"
+}
+```
+
+## Configuration
+Here is a sample configuration, for details, please refer to this [document](https://github.com/microsoft/azure-gradle-plugins/wiki/Webapp-Configuration).
+```groovy
+azurewebapp {
+    subscription = '<your subscription id>'
+    resourceGroup = '<your resource group>'
+    appName = '<your app name>'
+    pricingTier = '<price tier like 'P1v2'>'
+    region = '<region like 'westus'>'
+    runtime {
+      os = 'Linux'
+      webContainer = 'Tomcat 9.0' // or 'Java SE' if you want to run an executable jar
+      javaVersion = 'Java 8'
+    }
+    appSettings {
+        <key> = <value>
+    }
+
+    auth {
+        type = 'azure_cli' // support azure_cli, oauth2, device_code and service_principal
+    }
+}
+```
+
+## Usage
+
+### Deploy your web project to Azure App Service
+```shell
+gradle azureWebAppDeploy
+```
+
+## Feedback and Questions
+To report bugs or request new features, file issues on [Issues](https://github.com/microsoft/azure-gradle-plugins/issues). Or, ask questions on [Stack Overflow with tag azure-java-tools](https://stackoverflow.com/questions/tagged/azure-java-tools).
+
+## Data and Telemetry
+This project collects usage data and sends it to Microsoft to help improve our products and services.
+Read Microsoft's [privacy statement](https://privacy.microsoft.com/en-us/privacystatement) to learn more.
+If you would like to opt out of sending telemetry data to Microsoft, you can set `allowTelemetry` to false in the plugin configuration.
+Please read our [document](https://github.com/microsoft/azure-gradle-plugins/wiki/Configuration) to find more details about *allowTelemetry*.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17075863/127474565-9d9679a3-28bd-4b0a-99d5-33f921c2091c.png)
add readme for azure webapp gradle plugin.

## What problem is this PR solving?
We lack necessary readme document for new webapp plugin now. This PR have provided a simple readme for new users.

## What has been done in this PR?
 1.  the readme for new webapp plugin with sample configurations
 2.  the reference link to detailed configurations
 3. change log for 1.0.0
 4. version update for azure functions

[AB#1855224](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1855224)