### PR TITLE
Prepare for next release of gradle plugin for azure web app

### DIFF
--- a/azure-gradle-plugins-common/gradle.properties
+++ b/azure-gradle-plugins-common/gradle.properties
@@ -21,4 +21,4 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.2.0
+version               = 1.3.0-SNAPSHOT

--- a/azure-webapp-gradle-plugin/CHANGELOG.md
+++ b/azure-webapp-gradle-plugin/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to the "Azure WebApp Plugin for Gradle" will be documented in this file.
 - [Change Log](#change-log)
+  - [1.3.0](#130)
   - [1.2.0](#120)
   - [1.1.0](#110)
   - [1.0.0](#100)
+
+## 1.3.0
+- Support Tomcat 10.0 and Java SE 17 runtime
 
 ## 1.2.0
 - Support default value for region/pricing tier/webContainer/javaVersion [#1755](https://github.com/microsoft/azure-maven-plugins/pull/1755)

--- a/azure-webapp-gradle-plugin/gradle.properties
+++ b/azure-webapp-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.3.0
+version               = 1.4.0-SNAPSHOT
 
 pluginId                  = com.microsoft.azure.azurewebapp
 pluginShortName           = azurewebapp


### PR DESCRIPTION
- Bump change log for web app gradle plugin 1.3.0
- Bump version for next release
  - Update gradle plugin common to 1.2.0-SNAPSHOT
  - Update gradle plugin for web app to 1.3.0-SNAPSHOT