### PR TITLE
[Task #1962369] Refactor functions gradle plugin to adapt new functions java library

### DIFF
--- a/azure-functions-gradle-plugin/build.gradle
+++ b/azure-functions-gradle-plugin/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.reflections:reflections:0.9.12'
-    implementation 'com.microsoft.azure.functions:azure-functions-java-library:1.4.2'
     implementation 'org.atteo.classindex:classindex:3.11'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:30.1.1-jre'

--- a/azure-functions-gradle-plugin/gradle.properties
+++ b/azure-functions-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.9.0
+version               = 1.10.0-SNAPSHOT
 
 pluginId                  = com.microsoft.azure.azurefunctions
 pluginShortName           = azurefunctions

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/DeployHandler.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/DeployHandler.java
@@ -7,7 +7,6 @@ package com.microsoft.azure.plugin.functions.gradle.handler;
 
 import com.azure.core.management.AzureEnvironment;
 import com.google.common.base.Preconditions;
-import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.gradle.configuration.GradleRuntimeConfig;
 import com.microsoft.azure.gradle.temeletry.TelemetryAgent;
 import com.microsoft.azure.plugin.functions.gradle.GradleFunctionContext;
@@ -18,6 +17,7 @@ import com.microsoft.azure.toolkit.lib.appservice.config.RuntimeConfig;
 import com.microsoft.azure.toolkit.lib.appservice.entity.FunctionEntity;
 import com.microsoft.azure.toolkit.lib.appservice.function.FunctionApp;
 import com.microsoft.azure.toolkit.lib.appservice.function.FunctionAppBase;
+import com.microsoft.azure.toolkit.lib.appservice.function.core.AzureFunctionsAnnotationConstants;
 import com.microsoft.azure.toolkit.lib.appservice.model.FunctionDeployType;
 import com.microsoft.azure.toolkit.lib.appservice.model.JavaVersion;
 import com.microsoft.azure.toolkit.lib.appservice.model.OperatingSystem;
@@ -150,7 +150,7 @@ public class DeployHandler {
                 .collect(Collectors.toList());
             final List<FunctionEntity> anonymousTriggers = httpFunction.stream()
                 .filter(bindingResource -> bindingResource.getTrigger() != null &&
-                    StringUtils.equalsIgnoreCase(bindingResource.getTrigger().getProperty(AUTH_LEVEL), AuthorizationLevel.ANONYMOUS.toString()))
+                    StringUtils.equalsIgnoreCase(bindingResource.getTrigger().getProperty(AUTH_LEVEL), AzureFunctionsAnnotationConstants.ANONYMOUS))
                 .collect(Collectors.toList());
             if (CollectionUtils.isEmpty(httpFunction) || CollectionUtils.isEmpty(anonymousTriggers)) {
                 AzureMessager.getMessager().info(NO_ANONYMOUS_HTTP_TRIGGER);

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/PackageHandler.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/PackageHandler.java
@@ -92,7 +92,7 @@ public class PackageHandler {
     private static final String DEFAULT_LOCAL_SETTINGS_JSON = "{ \"IsEncrypted\": false, \"Values\": " +
         "{ \"FUNCTIONS_WORKER_RUNTIME\": \"java\" } }";
     private static final String DEFAULT_HOST_JSON = "{\"version\":\"2.0\",\"extensionBundle\":" +
-        "{\"id\":\"Microsoft.Azure.Functions.ExtensionBundle\",\"version\":\"[1.*, 2.0.0)\"}}\n";
+        "{\"id\":\"Microsoft.Azure.Functions.ExtensionBundle\",\"version\":\"[2.*, 3.0.0)\"}}\n";
     private static final String TRIGGER_TYPE = "triggerType";
 
     private final IProject project;

--- a/azure-gradle-plugins-common/gradle.properties
+++ b/azure-gradle-plugins-common/gradle.properties
@@ -21,4 +21,4 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.3.0
+version               = 1.4.0-SNAPSHOT

--- a/azure-webapp-gradle-plugin/gradle.properties
+++ b/azure-webapp-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.4.0
+version               = 1.5.0-SNAPSHOT
 
 pluginId                  = com.microsoft.azure.azurewebapp
 pluginShortName           = azurewebapp


### PR DESCRIPTION
- Refactor library exclude strategy for gradle plugin, for project with new functions-java-library (adapt to new function worker), only exclude functions-core-library and keep functions-java-library as new worker will not provide functions java library.
- Remove dependency for `azure-functions-java-library` in app service library, to generated `function.json` based on users' library.

refers https://github.com/microsoft/azure-maven-plugins/pull/1969

[AB#1962369](https://dev.azure.com/mseng/a4d27ce2-a42d-4b71-8eef-78cee9a9728e/_workitems/edit/1962369)