### PR TITLE
Fix for issue #166 - make allowTelemetry option to work

### DIFF
--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/AzureFunctionsPlugin.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/AzureFunctionsPlugin.java
@@ -45,11 +45,6 @@ public class AzureFunctionsPlugin implements Plugin<Project> {
         AzureMessager.setDefaultMessager(new GradleAzureMessager(project.getLogger()));
         final AzureFunctionsExtension extension = project.getExtensions().create(GRADLE_FUNCTION_EXTENSION,
                 AzureFunctionsExtension.class, project);
-        TelemetryAgent.getInstance().initTelemetry(GRADLE_PLUGIN_NAME,
-            StringUtils.firstNonBlank(AzureFunctionsPlugin.class.getPackage().getImplementationVersion(), "develop"), // default version: develop
-            BooleanUtils.isNotFalse(extension.getAllowTelemetry()));
-        TelemetryAgent.getInstance().showPrivacyStatement();
-
         try {
             CacheManager.evictCache(CacheEvict.ALL, CacheEvict.ALL);
         } catch (ExecutionException e) {
@@ -86,7 +81,15 @@ public class AzureFunctionsPlugin implements Plugin<Project> {
         });
 
         project.afterEvaluate(projectAfterEvaluation -> {
+
             mergeCommandLineParameters(extension);
+            TelemetryAgent.getInstance().initTelemetry(GRADLE_PLUGIN_NAME,
+                StringUtils.firstNonBlank(AzureFunctionsPlugin.class.getPackage().getImplementationVersion(), "develop"), // default version: develop
+                BooleanUtils.isNotFalse(extension.getAllowTelemetry()));
+            if (BooleanUtils.isNotFalse(extension.getAllowTelemetry())) {
+                TelemetryAgent.getInstance().showPrivacyStatement();
+            }
+
             packageTask.configure(task -> task.dependsOn("jar"));
             packageZipTask.configure(task -> task.dependsOn(packageTask));
             runTask.configure(task -> task.dependsOn(packageTask));

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/DeployHandler.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/handler/DeployHandler.java
@@ -357,7 +357,7 @@ public class DeployHandler {
         final int runtimeVersion;
         final int artifactCompileVersion;
         try {
-            runtimeVersion  = Utils.getJavaMajorVersion(javaVersion);
+            runtimeVersion = Utils.getJavaMajorVersion(javaVersion);
             artifactCompileVersion = Utils.getArtifactCompileVersion(file);
         } catch (RuntimeException e) {
             AzureMessager.getMessager().info("Failed to get version of your artifact, skip artifact compatibility test");


### PR DESCRIPTION
I've tested this two ways:
- ./gradlew -DallowTelemetry=true|false the property merge function will set the property accordingly
- ./gradlew with azureFunctions { allowTelemetry = true|false } in build.gradle
    
Also moved the mergeCommandLineParameters() function to execute prior to the check for allowTelemetry allowing the property to be set. 

Display the disclaimer of privacy statement to only when allowTelemetry is evaluated to true, which is still the default.

