### PR TITLE
Issue #166: Use the AzureTelemetryClient's default constructor

### DIFF
--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/AzureFunctionsPlugin.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/AzureFunctionsPlugin.java
@@ -51,9 +51,6 @@ public class AzureFunctionsPlugin implements Plugin<Project> {
             //ignore
         }
 
-        Azure.az().config().setLogLevel(HttpLogDetailLevel.NONE.name());
-        Azure.az().config().setUserAgent(TelemetryAgent.getInstance().getUserAgent());
-
         final TaskContainer tasks = project.getTasks();
 
         final TaskProvider<PackageTask> packageTask = tasks.register("azureFunctionsPackage", PackageTask.class, task -> {
@@ -83,10 +80,15 @@ public class AzureFunctionsPlugin implements Plugin<Project> {
         project.afterEvaluate(projectAfterEvaluation -> {
 
             mergeCommandLineParameters(extension);
+
             TelemetryAgent.getInstance().initTelemetry(GRADLE_PLUGIN_NAME,
                 StringUtils.firstNonBlank(AzureFunctionsPlugin.class.getPackage().getImplementationVersion(), "develop"), // default version: develop
                 BooleanUtils.isNotFalse(extension.getAllowTelemetry()));
-            TelemetryAgent.getInstance().showPrivacyStatement();
+            if (BooleanUtils.isNotFalse(extension.getAllowTelemetry())) {
+                TelemetryAgent.getInstance().showPrivacyStatement();
+            }
+            Azure.az().config().setUserAgent(TelemetryAgent.getInstance().getUserAgent());
+            Azure.az().config().setLogLevel(HttpLogDetailLevel.NONE.name());
 
             packageTask.configure(task -> task.dependsOn("jar"));
             packageZipTask.configure(task -> task.dependsOn(packageTask));

--- a/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/temeletry/TelemetryAgent.java
+++ b/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/temeletry/TelemetryAgent.java
@@ -74,11 +74,8 @@ public class TelemetryAgent implements TelemetryConfiguration {
         this.pluginName = pluginName;
         this.pluginVersion = pluginVersion;
         this.allowTelemetry = allowTelemetry;
-        telemetryProxy = new AzureTelemetryClient(this.getTelemetryProperties());
-        if (!allowTelemetry) {
-            telemetryProxy.trackEvent(TELEMETRY_NOT_ALLOWED);
-            telemetryProxy.disable();
-        } else {
+        if (allowTelemetry) {
+            telemetryProxy = new AzureTelemetryClient(this.getTelemetryProperties());
             AzureTelemeter.setClient(telemetryProxy);
             AzureTelemeter.setCommonProperties(this.getTelemetryProperties());
             AzureTelemeter.setEventNamePrefix("AzurePlugin.Gradle");
@@ -86,7 +83,9 @@ public class TelemetryAgent implements TelemetryConfiguration {
     }
 
     public void addDefaultProperty(String key, String value) {
-        this.telemetryProxy.addDefaultProperty(key, value);
+        if (telemetryProxy != null) {
+            this.telemetryProxy.addDefaultProperty(key, value);
+        }
     }
 
     public void addDefaultProperties(Map<String, String> properties) {


### PR DESCRIPTION
Re-organizing the code here, this will stop the AzureTelemetryClient from sending the message for QuickPulseService
 and others. This is because of implicit initialization of classes (even when not intended to be used) pulls in
 yet other dependencies.

The following network requests are no longer being issued. 
- TCP_MISS/200 499 POST https://rt.services.visualstudio.com/QuickPulseService.svc/ping? - HIER_DIRECT/23.100.122.113 
- TCP_MISS/200 619 POST https://dc.services.visualstudio.com/v2/track - HIER_DIRECT/40.78.253.202 application/json