### PR TITLE
Stop NPE when pricing tier is not specified within build.gradle file

### DIFF
--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/GradleFunctionContext.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/GradleFunctionContext.java
@@ -195,7 +195,7 @@ public class GradleFunctionContext {
         result.put(FUNCTION_RUNTIME_KEY, StringUtils.isEmpty(os) ? "" : os);
         result.put(FUNCTION_IS_DOCKER_KEY, String.valueOf(isDockerFunction));
         result.put(FUNCTION_REGION_KEY, getRegion());
-        result.put(FUNCTION_PRICING_KEY, getPricingTier());
+        result.put(FUNCTION_PRICING_KEY, StringUtils.isEmpty(getPricingTier()) ? "" : getPricingTier());
         result.put(DISABLE_APP_INSIGHTS_KEY, String.valueOf(isDisableAppInsights()));
         result.put(DEPLOY_TO_SLOT_KEY, String.valueOf(StringUtils.isEmpty(getDeploymentSlotName())));
         return result;


### PR DESCRIPTION
When a pricingTier is not specified within the build.gradle file, a NullPointerException is thrown when attempting to set up the telemetry details, as it is not permissible to insert a NULL value into a HashMap.

pricingTier can be NULL when using an App Service Plan instead of a Consumption plan.

This change sets the pricing key in the telemetry to be an empty string instead of NULL in this case.