### PR TITLE
Project fix and CVE fixes

### DIFF
--- a/azure-functions-gradle-plugin/build.gradle
+++ b/azure-functions-gradle-plugin/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.reflections:reflections:0.9.12'
     implementation 'org.atteo.classindex:classindex:3.11'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.google.guava:guava:30.1.1-jre'
+    implementation 'com.google.guava:guava:32.1.0-jre'
     implementation 'org.apache.maven:maven-artifact:3.8.1'
     implementation 'org.fusesource.jansi:jansi:1.18'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-properties:2.14.1'

--- a/azure-functions-gradle-plugin/build.gradle
+++ b/azure-functions-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: "io.freefair.aspectj.post-compile-weaving"
 
 dependencies {
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.reflections:reflections:0.9.12'

--- a/azure-functions-gradle-plugin/build.gradle
+++ b/azure-functions-gradle-plugin/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.reflections:reflections:0.9.12'
     implementation 'org.atteo.classindex:classindex:3.11'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation 'org.apache.maven:maven-artifact:3.8.1'
     implementation 'org.fusesource.jansi:jansi:1.18'

--- a/azure-gradle-plugins-common/build.gradle
+++ b/azure-gradle-plugins-common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.google.guava:guava:30.1.1-jre'
+    implementation 'com.google.guava:guava:32.1.0-jre'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.microsoft.azure:azure-toolkit-common-lib:' + azureToolkitVersion
     implementation 'com.microsoft.azure:azure-toolkit-appservice-lib:'  + azureToolkitVersion

--- a/azure-gradle-plugins-common/build.gradle
+++ b/azure-gradle-plugins-common/build.gradle
@@ -7,7 +7,7 @@ ext {
 dependencies {
     compile gradleApi()
 
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation 'org.slf4j:slf4j-api:1.7.36'

--- a/azure-webapp-gradle-plugin/build.gradle
+++ b/azure-webapp-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: "io.freefair.aspectj.post-compile-weaving"
 
 dependencies {
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.code.gson:gson:2.8.7'

--- a/azure-webapp-gradle-plugin/build.gradle
+++ b/azure-webapp-gradle-plugin/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.google.guava:guava:30.1.1-jre'
+    implementation 'com.google.guava:guava:32.1.0-jre'
 
     implementation 'org.fusesource.jansi:jansi:1.18'
     implementation 'com.microsoft.azure:applicationinsights-core:2.6.3'

--- a/azure-webapp-gradle-plugin/build.gradle
+++ b/azure-webapp-gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:30.1.1-jre'
 
     implementation 'org.fusesource.jansi:jansi:1.18'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "net.linguica.maven-settings" version "0.5" apply false
     id "com.gradle.plugin-publish" version "0.15.0" apply false
-    id "nu.studer.credentials" version "2.1" apply false
+    id "nu.studer.credentials" version "2.2" apply false
     id "com.github.ben-manes.versions" version "0.39.0"  apply false
     id "io.freefair.aspectj.post-compile-weaving" version "6.0.0-m2"
 }


### PR DESCRIPTION
I included in this PR few items
- I upgraded nu.studer.credentials to 2.2 because it nu.studer:java-ordered-properties version 1.0.2 dependency was removed from JCenter
- Upgraded commons-io:commons-io to 2.14.0 to fix CVE-2024-47554
- Upgraded com.google.code.gson:gson to 2.8.9 to fix CVE-2022-25647
- Upgraded com.google.guava:guava to 32.1.0-jre to fix CVE-2020-8908 and CVE-2023-2976