### PR TITLE
Prepare 1.17.0 release with Gradle 9 support

### DIFF
--- a/azure-functions-gradle-plugin/CHANGELOG.md
+++ b/azure-functions-gradle-plugin/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to the "Azure Function Plugin for Gradle" will be documented in this file.
 - [Change Log](#change-log)
+  - [1.17.0](#1170)
   - [1.15.0](#1150)
   - [1.11.0](#1110)
   - [1.10.0](#1100)
@@ -14,6 +15,10 @@ All notable changes to the "Azure Function Plugin for Gradle" will be documented
   - [1.2.0](#120)
   - [1.1.0](#110)
   - [1.0.0](#100)
+
+## 1.17.0
+- Support Gradle 9 by replacing deprecated `JavaPluginConvention` and `BasePluginConvention` with `JavaPluginExtension` and `BasePluginExtension`, and migrating from `getExecResult()` to the `Provider`-based exec API ([#196](https://github.com/microsoft/azure-gradle-plugins/pull/196))
+- Bump Lombok to 1.18.42 and Guava to 33.5.0-jre
 
 ## 1.15.0
 - Migrate to use `stacks` API to get and validate function app runtime stacks

--- a/azure-functions-gradle-plugin/gradle.properties
+++ b/azure-functions-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.16.1
+version               = 1.17.0
 
 pluginId                  = com.microsoft.azure.azurefunctions
 pluginShortName           = azurefunctions


### PR DESCRIPTION
## Summary
Bumps `azure-functions-gradle-plugin` to **1.17.0** and adds the corresponding `CHANGELOG.md` entry for the Gradle 9 support fix already merged in #196.                         
                                                                                                                                                                                   
  ## Why
                                                                                                                                                                                   
The Gradle 9 compatibility fix has been on `master` since October 2025 (PR #196), but no new version has been released to the [Gradle Plugin 
Portal](https://plugins.gradle.org/plugin/com.microsoft.azure.azurefunctions) — the latest published is still `1.16.1` from July 2024, which is **not** Gradle-9-ready. Without a
published release, downstream consumers are stuck on Gradle 8.x.                                                                                                                
                                                                                                                                                                                   
  This PR prepares a release that can be cut directly from `master`.
                                                                                                                                                                                   
  ## Verified scope
                                                                                                                                                                                   
I checked all commits between the `1.16.1` version bump and current `master`. The only code change in `azure-functions-gradle-plugin/` is `aee2976` (the Gradle 9 fix). So
`1.17.0` would contain exactly the Gradle 9 support and nothing else — minor bump is appropriate semver.                                                                         
                                                                                                          
  ## Note on CHANGELOG history                                                                                                                                                     
                              
The `CHANGELOG.md` is already missing entries for `1.16.0` and `1.16.1` releases (pre-existing gap, not introduced by this PR). I intentionally did not try to backfill them,
since I'd rather not put words in past releases' notes — that's better done by the maintainers who shipped them. This PR only adds the `1.17.0` entry.                           
                                                                                                                                                        
  ## Verification                                                                                                                                                                  
                  
Fix has been merged for ~6 months and used by the community via local builds; `master` builds clean with Gradle 9.x. Tested locally: `./gradlew azureFunctionsPackage` works on
Gradle 9.4.1.      

  ## Note to maintainers                                                                                                                                                           
                  
After merging this PR, would you be able to cut tag `v1.17.0` from `master` and trigger the publish pipeline to the Gradle Plugin Portal? Several downstream users (see #184) are
waiting on this release. Thanks!             