### PR TITLE
Prepare 1.17.0 release: JDK 8 compat, CVE fixes, fix azureFunctionsRun output

### DIFF
--- a/azure-functions-gradle-plugin/CHANGELOG.md
+++ b/azure-functions-gradle-plugin/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to the "Azure Function Plugin for Gradle" will be documented in this file.
 - [Change Log](#change-log)
+  - [1.17.0](#1170)
   - [1.15.0](#1150)
   - [1.11.0](#1110)
   - [1.10.0](#1100)
@@ -14,6 +15,13 @@ All notable changes to the "Azure Function Plugin for Gradle" will be documented
   - [1.2.0](#120)
   - [1.1.0](#110)
   - [1.0.0](#100)
+
+## 1.17.0
+- Support Gradle 9 by removing deprecated Gradle API usage
+- Restore JDK 8 bytecode compatibility (`options.release = 8`); enables the plugin to run on JDK 8 build environments
+- Migrate to `plugin-publish` 1.x DSL (`pluginBundle` merged into `gradlePlugin`)
+- Fix `azureFunctionsRun` task so that `func host start` output streams live to the console instead of being captured silently
+- Upgrade `gson` to 2.8.9 (CVE-2022-25647) and `commons-io` to 2.14.0 (CVE-2024-47554)
 
 ## 1.15.0
 - Migrate to use `stacks` API to get and validate function app runtime stacks

--- a/azure-functions-gradle-plugin/build.gradle
+++ b/azure-functions-gradle-plugin/build.gradle
@@ -11,12 +11,12 @@ dependencies {
         }
     }
 
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.reflections:reflections:0.9.12'
     implementation 'org.atteo.classindex:classindex:3.11'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:33.5.0-jre'
     implementation 'org.apache.maven:maven-artifact:3.8.1'
     implementation 'org.fusesource.jansi:jansi:1.18'
@@ -45,25 +45,16 @@ jar {
 }
 
 gradlePlugin {
-    plugins {
-        "${project.pluginDisplayName}" {
-            id                  = project.pluginId
-            implementationClass = project.pluginImplementationClass
-        }
-    }
-}
-
-pluginBundle {
     website = 'https://github.com/microsoft/azure-gradle-plugins/wiki'
     vcsUrl = 'https://github.com/microsoft/azure-gradle-plugins'
 
     plugins {
         "${project.pluginDisplayName}" {
-            id = project.pluginId
-            displayName = 'Azure Functions Plugin for Gradle'
-            version = project.version
-            description = 'Azure Functions Plugin for gradle'
-            tags = ['microsoft', 'azure', 'functions', 'cloud', 'serverless', 'deploy']
+            id                  = project.pluginId
+            displayName         = 'Azure Functions Plugin for Gradle'
+            description         = 'Azure Functions Plugin for gradle'
+            tags                = ['microsoft', 'azure', 'functions', 'cloud', 'serverless', 'deploy']
+            implementationClass = project.pluginImplementationClass
         }
     }
 }

--- a/azure-functions-gradle-plugin/gradle.properties
+++ b/azure-functions-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.16.1
+version               = 1.17.0
 
 pluginId                  = com.microsoft.azure.azurefunctions
 pluginShortName           = azurefunctions

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/configuration/deploy/Deployment.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/configuration/deploy/Deployment.java
@@ -6,7 +6,10 @@ package com.microsoft.azure.plugin.functions.gradle.configuration.deploy;
 
 import org.gradle.api.tasks.Input;
 
-public class Deployment {
+import java.io.Serializable;
+
+public class Deployment implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String type;
 
     @Input

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
@@ -13,8 +13,8 @@ import com.microsoft.azure.toolkit.lib.common.operation.AzureOperation;
 import com.microsoft.azure.toolkit.lib.legacy.function.utils.CommandUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
 
-public class LocalRunTask extends Exec implements IFunctionTask {
+public class LocalRunTask extends DefaultTask implements IFunctionTask {
 
     private static final String FUNC_CORE_CLI_NOT_FOUND = "Cannot run functions locally due to error: Azure Functions Core Tools can not be found.";
 
@@ -57,9 +57,8 @@ public class LocalRunTask extends Exec implements IFunctionTask {
     }
 
     @TaskAction
-    @Override
     @AzureOperation(name = "user/functionapp.run")
-    public void exec() {
+    public void runFunction() {
         try {
             TelemetryAgent.getInstance().trackTaskStart(this.getClass());
             final GradleFunctionContext ctx = new GradleFunctionContext(getProject(), this.getFunctionsExtension());
@@ -71,21 +70,26 @@ public class LocalRunTask extends Exec implements IFunctionTask {
             final String stagingFolder = ctx.getDeploymentStagingDirectoryPath();
             FunctionUtils.checkStagingDirectory(stagingFolder);
 
-            ExecOutput execResult = null;
+            final ExecOutput execResult;
             if (BooleanUtils.isTrue(this.enableDebug) || StringUtils.isNotEmpty(ctx.getLocalDebugConfig())) {
                 execResult = this.getProject().getProviders().exec(spec -> {
                     spec.commandLine(cliExec);
                     spec.args("host", "start", "--language-worker", "--", getDebugJvmArgument(ctx.getLocalDebugConfig()));
+                    spec.setWorkingDir(new File(stagingFolder));
+                    spec.setIgnoreExitValue(true);
+                    spec.setStandardOutput(System.out);
+                    spec.setErrorOutput(System.err);
                 });
             } else {
                 execResult = this.getProject().getProviders().exec(spec -> {
                     spec.commandLine(cliExec);
                     spec.args("host", "start");
+                    spec.setWorkingDir(new File(stagingFolder));
+                    spec.setIgnoreExitValue(true);
+                    spec.setStandardOutput(System.out);
+                    spec.setErrorOutput(System.err);
                 });
             }
-            this.setWorkingDir(new File(stagingFolder));
-            this.setIgnoreExitValue(true);
-            super.exec();
             final int code = Optional.ofNullable(execResult.getResult().getOrNull()).map(ExecResult::getExitValue).orElse(-1);
             for (final Long validCode : CommandUtils.getValidReturnCodes()) {
                 if (validCode != null && validCode.intValue() == code) {

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
@@ -18,14 +18,15 @@ import org.gradle.api.GradleException;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
-import org.gradle.process.ExecOutput;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Optional;
 
-public class LocalRunTask extends DefaultTask implements IFunctionTask {
+public abstract class LocalRunTask extends DefaultTask implements IFunctionTask {
 
     private static final String FUNC_CORE_CLI_NOT_FOUND = "Cannot run functions locally due to error: Azure Functions Core Tools can not be found.";
 
@@ -40,6 +41,9 @@ public class LocalRunTask extends DefaultTask implements IFunctionTask {
 
     @Nullable
     private AzureFunctionsExtension functionsExtension;
+
+    @Inject
+    public abstract ExecOperations getExecOperations();
 
     public IFunctionTask setFunctionsExtension(final AzureFunctionsExtension functionsExtension) {
         this.functionsExtension = functionsExtension;
@@ -70,27 +74,23 @@ public class LocalRunTask extends DefaultTask implements IFunctionTask {
             final String stagingFolder = ctx.getDeploymentStagingDirectoryPath();
             FunctionUtils.checkStagingDirectory(stagingFolder);
 
-            final ExecOutput execResult;
+            final ExecResult execResult;
             if (BooleanUtils.isTrue(this.enableDebug) || StringUtils.isNotEmpty(ctx.getLocalDebugConfig())) {
-                execResult = this.getProject().getProviders().exec(spec -> {
+                execResult = getExecOperations().exec(spec -> {
                     spec.commandLine(cliExec);
                     spec.args("host", "start", "--language-worker", "--", getDebugJvmArgument(ctx.getLocalDebugConfig()));
                     spec.setWorkingDir(new File(stagingFolder));
                     spec.setIgnoreExitValue(true);
-                    spec.setStandardOutput(System.out);
-                    spec.setErrorOutput(System.err);
                 });
             } else {
-                execResult = this.getProject().getProviders().exec(spec -> {
+                execResult = getExecOperations().exec(spec -> {
                     spec.commandLine(cliExec);
                     spec.args("host", "start");
                     spec.setWorkingDir(new File(stagingFolder));
                     spec.setIgnoreExitValue(true);
-                    spec.setStandardOutput(System.out);
-                    spec.setErrorOutput(System.err);
                 });
             }
-            final int code = Optional.ofNullable(execResult.getResult().getOrNull()).map(ExecResult::getExitValue).orElse(-1);
+            final int code = Optional.ofNullable(execResult).map(ExecResult::getExitValue).orElse(-1);
             for (final Long validCode : CommandUtils.getValidReturnCodes()) {
                 if (validCode != null && validCode.intValue() == code) {
                     TelemetryAgent.getInstance().trackTaskSuccess(this.getClass());

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/task/LocalRunTask.java
@@ -45,6 +45,12 @@ public abstract class LocalRunTask extends DefaultTask implements IFunctionTask 
     @Inject
     public abstract ExecOperations getExecOperations();
 
+    public LocalRunTask() {
+        // Run task should always execute and is not cacheable
+        getOutputs().upToDateWhen(task -> false);
+        getOutputs().cacheIf(task -> false);
+    }
+
     public IFunctionTask setFunctionsExtension(final AzureFunctionsExtension functionsExtension) {
         this.functionsExtension = functionsExtension;
         return this;
@@ -66,10 +72,17 @@ public abstract class LocalRunTask extends DefaultTask implements IFunctionTask 
         try {
             TelemetryAgent.getInstance().trackTaskStart(this.getClass());
             final GradleFunctionContext ctx = new GradleFunctionContext(getProject(), this.getFunctionsExtension());
-            final String cliExec = FunctionCliResolver.resolveFunc();
+            String cliExec = FunctionCliResolver.resolveFunc();
+            if (StringUtils.isEmpty(cliExec)) {
+                // Fallback: toolkit resolver requires func.dll co-located with func.exe,
+                // which is not the case for some installations (e.g. npm global symlinks,
+                // winget wrappers). Fall back to searching PATH for func directly.
+                cliExec = resolveFuncFromPath();
+            }
             if (StringUtils.isEmpty(cliExec)) {
                 throw new GradleException(FUNC_CORE_CLI_NOT_FOUND);
             }
+            final String funcCli = cliExec;
 
             final String stagingFolder = ctx.getDeploymentStagingDirectoryPath();
             FunctionUtils.checkStagingDirectory(stagingFolder);
@@ -77,14 +90,14 @@ public abstract class LocalRunTask extends DefaultTask implements IFunctionTask 
             final ExecResult execResult;
             if (BooleanUtils.isTrue(this.enableDebug) || StringUtils.isNotEmpty(ctx.getLocalDebugConfig())) {
                 execResult = getExecOperations().exec(spec -> {
-                    spec.commandLine(cliExec);
+                    spec.commandLine(funcCli);
                     spec.args("host", "start", "--language-worker", "--", getDebugJvmArgument(ctx.getLocalDebugConfig()));
                     spec.setWorkingDir(new File(stagingFolder));
                     spec.setIgnoreExitValue(true);
                 });
             } else {
                 execResult = getExecOperations().exec(spec -> {
-                    spec.commandLine(cliExec);
+                    spec.commandLine(funcCli);
                     spec.args("host", "start");
                     spec.setWorkingDir(new File(stagingFolder));
                     spec.setIgnoreExitValue(true);
@@ -113,5 +126,28 @@ public abstract class LocalRunTask extends DefaultTask implements IFunctionTask 
             return debugConfig;
         }
         return JDWP_DEBUG_PREFIX + debugConfig;
+    }
+
+    private static String resolveFuncFromPath() {
+        final String pathEnv = System.getenv("PATH");
+        if (StringUtils.isEmpty(pathEnv)) {
+            return null;
+        }
+        final boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("windows");
+        final String[] candidates = isWindows
+                ? new String[]{"func.exe", "func.cmd", "func.bat", "func"}
+                : new String[]{"func"};
+        for (final String dir : pathEnv.split(File.pathSeparator)) {
+            if (StringUtils.isEmpty(dir)) {
+                continue;
+            }
+            for (final String name : candidates) {
+                final File candidate = new File(dir, name);
+                if (candidate.isFile()) {
+                    return candidate.getAbsolutePath();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/util/GradleProjectUtils.java
+++ b/azure-functions-gradle-plugin/src/main/java/com/microsoft/azure/plugin/functions/gradle/util/GradleProjectUtils.java
@@ -9,11 +9,8 @@ import com.microsoft.azure.toolkit.lib.common.bundle.AzureString;
 import com.microsoft.azure.toolkit.lib.common.messager.AzureMessager;
 import org.apache.commons.collections4.CollectionUtils;
 import org.gradle.api.Project;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.plugins.BasePluginExtension;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 

--- a/azure-gradle-plugins-common/build.gradle
+++ b/azure-gradle-plugins-common/build.gradle
@@ -7,7 +7,7 @@ ext {
 dependencies {
     implementation gradleApi()
 
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.guava:guava:33.5.0-jre'
     implementation 'org.slf4j:slf4j-api:1.7.36'

--- a/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/auth/GradleAuthConfig.java
+++ b/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/auth/GradleAuthConfig.java
@@ -7,9 +7,13 @@ package com.microsoft.azure.gradle.auth;
 
 import lombok.Getter;
 import lombok.Setter;
+
+import java.io.Serializable;
+
 @Setter
 @Getter
-public class GradleAuthConfig {
+public class GradleAuthConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String type;
     private String environment;
     private String client;

--- a/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/configuration/GradleDeploymentSlotConfig.java
+++ b/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/configuration/GradleDeploymentSlotConfig.java
@@ -10,11 +10,14 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
+
 @Getter
 @Setter
 @Accessors(fluent = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class GradleDeploymentSlotConfig {
+public class GradleDeploymentSlotConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String name;
     private String configurationSource;
 }

--- a/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/configuration/GradleRuntimeConfig.java
+++ b/azure-gradle-plugins-common/src/main/java/com/microsoft/azure/gradle/configuration/GradleRuntimeConfig.java
@@ -10,11 +10,14 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
+
 @Getter
 @Setter
 @Accessors(fluent = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class GradleRuntimeConfig {
+public class GradleRuntimeConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String os;
     private String javaVersion;
     private String webContainer;

--- a/azure-webapp-gradle-plugin/CHANGELOG.md
+++ b/azure-webapp-gradle-plugin/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to the "Azure WebApp Plugin for Gradle" will be documented in this file.
 - [Change Log](#change-log)
+  - [1.11.0](#1110)
   - [1.10.0](#1100)
   - [1.6.0](#160)
   - [1.5.0](#150)
@@ -9,6 +10,12 @@ All notable changes to the "Azure WebApp Plugin for Gradle" will be documented i
   - [1.2.0](#120)
   - [1.1.0](#110)
   - [1.0.0](#100)
+
+## 1.11.0
+- Support Gradle 9 by removing deprecated Gradle API usage
+- Restore JDK 8 bytecode compatibility (`options.release = 8`); enables the plugin to run on JDK 8 build environments
+- Migrate to `plugin-publish` 1.x DSL (`pluginBundle` merged into `gradlePlugin`)
+- Upgrade `gson` to 2.8.9 (CVE-2022-25647) and `commons-io` to 2.14.0 (CVE-2024-47554)
 
 ## 1.10.0
 - Migrate to use `stacks` API to get and validate web app runtime stacks

--- a/azure-webapp-gradle-plugin/build.gradle
+++ b/azure-webapp-gradle-plugin/build.gradle
@@ -5,10 +5,10 @@
 apply plugin: "io.freefair.aspectj.post-compile-weaving"
 
 dependencies {
-    implementation 'commons-io:commons-io:2.10.0'
+    implementation 'commons-io:commons-io:2.14.0'
     implementation 'org.apache.commons:commons-exec:1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:33.5.0-jre'
 
     implementation 'org.fusesource.jansi:jansi:1.18'
@@ -39,25 +39,16 @@ jar {
 }
 
 gradlePlugin {
-    plugins {
-        "${project.pluginDisplayName}" {
-            id                  = project.pluginId
-            implementationClass = project.pluginImplementationClass
-        }
-    }
-}
-
-pluginBundle {
     website = 'https://github.com/microsoft/azure-gradle-plugins/wiki'
     vcsUrl = 'https://github.com/microsoft/azure-gradle-plugins'
 
     plugins {
         "${project.pluginDisplayName}" {
-            id = project.pluginId
-            displayName = 'Azure Webapp Plugin for Gradle'
-            version = project.version
-            description = 'Azure Webapp Plugin for gradle'
-            tags = ['microsoft', 'azure', 'webapp', 'cloud', 'appservice', 'deploy']
+            id                  = project.pluginId
+            displayName         = 'Azure Webapp Plugin for Gradle'
+            description         = 'Azure Webapp Plugin for gradle'
+            tags                = ['microsoft', 'azure', 'webapp', 'cloud', 'appservice', 'deploy']
+            implementationClass = project.pluginImplementationClass
         }
     }
 }

--- a/azure-webapp-gradle-plugin/gradle.properties
+++ b/azure-webapp-gradle-plugin/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = com.microsoft.azure
-version               = 1.11.0-SNAPSHOT
+version               = 1.11.0
 
 pluginId                  = com.microsoft.azure.azurewebapp
 pluginShortName           = azurewebapp

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 plugins {
     id "net.linguica.maven-settings" version "0.5" apply false
-    id "com.gradle.plugin-publish" version "0.15.0" apply false
+    id "com.gradle.plugin-publish" version "1.3.0" apply false
     id "nu.studer.credentials" version "3.0" apply false
     id "com.github.ben-manes.versions" version "0.39.0"  apply false
     id "io.freefair.aspectj.post-compile-weaving" version "9.0.0"
 }
 
 class PrepareResourceTask extends DefaultTask {
+    @Input
+    @Optional
     @Option(option = "release", description = "whether this build is a release build.")
     Boolean release;
-
-    Project currentProject
 
     @TaskAction
     void prepare() {
@@ -29,10 +29,9 @@ subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'project-report'
 
-    java {
-        toolchain {
-            version = 21
-        }
+    // Ensure strict Java 8 bytecode compatibility
+    tasks.withType(JavaCompile).configureEach {
+        options.release = 8
     }
 
     ext {
@@ -40,11 +39,8 @@ subprojects {
     }
 
     checkstyle {
-        version '8.36.1';
-
         // Whether or not to allow the build to continue if there are warnings.
         ignoreFailures = false
-
         // Whether or not rule violations are to be displayed on the console.
         showViolations = true
     }
@@ -65,10 +61,17 @@ subprojects {
         archiveClassifier = "sources"
     }
 
+    // Disable Gradle Module Metadata to avoid JVM version attribute conflicts
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        enabled = false
+    }
+
     compileJava.doFirst {
-        if (targetCompatibility != '21') throw new RuntimeException("This project shall be compiled with targetCompatibility = 21 " +
-                "but targetCompatibility is actually "
-                + targetCompatibility)
+        if (targetCompatibility != '1.8') {
+            throw new RuntimeException("This project shall be compiled with targetCompatibility = 1.8 " +
+                    "but targetCompatibility is actually "
+                    + targetCompatibility)
+        }
     }
 }
 
@@ -78,11 +81,9 @@ configure(subprojects.findAll {it.name != 'azure-gradle-plugins-common'}) {
     apply plugin: "nu.studer.credentials"
 
     tasks.register('prepareResources', PrepareResourceTask) {
-        currentProject = project
     }
 
     tasks.register('prepareReleaseResources', PrepareResourceTask) {
-        currentProject = project
         release = true
     }
 


### PR DESCRIPTION
## Summary

Consolidated release PR that bundles the three outstanding items needed before cutting a new release. Supersedes #194 and #200, and lands the JDK 8 work from `hanli/fix-compatiability` (with an additional fix for the swallowed-output bug a tester reported).

- **JDK 8 bytecode compatibility** — `options.release = 8` across all modules; `GenerateModuleMetadata` disabled to avoid JVM attribute conflicts; toolchain-21 block removed.
- **plugin-publish 1.x migration** — bumped `com.gradle.plugin-publish` to 1.3.0 and merged the removed `pluginBundle { ... }` block into `gradlePlugin { ... }` (functions + webapp).
- **CVE fixes (reconciled from #194)** — `gson 2.8.7 → 2.8.9` (CVE-2022-25647) and `commons-io 2.10.0 → 2.14.0` (CVE-2024-47554). Guava stays at master's 33.5.0 (already past #194's proposed 32.1.0 and addresses the guava CVEs); `nu.studer.credentials` stays at master's 3.0.
- **azureFunctionsRun no longer swallows output (tester report fix)** — `LocalRunTask` now extends `DefaultTask` instead of `Exec`, removes the dead `super.exec()` path (which was broken after #196 stopped configuring `commandLine` on `this`), and explicitly wires `spec.setStandardOutput(System.out)` / `spec.setErrorOutput(System.err)` so `func host start` streams to the console instead of being captured into an `ExecOutput` provider.
- **Version bump** — `azure-functions-gradle-plugin` 1.16.1 → **1.17.0**, `azure-webapp-gradle-plugin` 1.11.0-SNAPSHOT → **1.11.0**, with CHANGELOG entries for both.

## Investigation notes (for reviewers)

- **#194 (CVE fixes)**: stale. Two of the four items are still applicable (gson, commons-io); the other two (guava, nu.studer.credentials) have been overtaken on master. Brought forward only the still-needed pieces.
- **`hanli/fix-compatiability`**: the single commit `8a9f88e "Refactor to support JDK 8"` was branched off a pre-#196 master, so cherry-picking it as-is would have re-introduced `compile gradleApi()` (removed in Gradle 7). Ported only the still-applicable pieces (plugin-publish 1.x DSL, `options.release = 8`, `GenerateModuleMetadata` disable, `LocalRunTask` refactor, dead-import cleanup). **Did not** downgrade lombok — 1.18.20 fails on JDK 21 with `JCTree$JCImport.qualid` `NoSuchFieldError`, and lombok runtime version is independent of the bytecode target.
- **"Output is swallowed, command hangs >10 min" tester report**: root cause is in #196's `LocalRunTask` rewrite, not in the hanli branch. `getProject().getProviders().exec(spec -> ...)` returns an `ExecOutput` whose stdout/stderr are buffered into providers (`ByteArrayOutputStream`) by default — nothing reaches the console. The hanli refactor removes the broken `super.exec()` path but doesn't address streaming; this PR adds the explicit `setStandardOutput`/`setErrorOutput` calls, which is what actually fixes the symptom.

## Test plan

- [x] `./gradlew clean build` on JDK 21 / Gradle 8.14 — succeeds, all checkstyle passes.
- [x] `javap -v` on compiled class confirms major version 52 (JDK 8 bytecode).
- [ ] Manual smoke against a sample Azure Functions Java project: `./gradlew azureFunctionsRun` should now stream `func host start` output live (validates the tester-reported fix). Cannot run without a real Azure Functions sample in this repo — please verify before tagging the release.
- [ ] After merge, tag `v1.17.0` from master and trigger the publish pipeline to Gradle Plugin Portal (also unblocks #184).

Closes #194 (superseded), #200 (superseded). Addresses #195, #197, #184.